### PR TITLE
Fixing a bug for loading data in non-parallel mode

### DIFF
--- a/dualip/src/main/scala/com/linkedin/dualip/problem/MooSolver.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/problem/MooSolver.scala
@@ -174,6 +174,7 @@ object MooSolverDualObjectiveFunction extends DualPrimalObjectiveLoader {
 
     val budget = IOUtility.readDataFrame(inputPaths.vectorBPath, inputPaths.format)
       .map{case Row(_c0: Number, _c1: Number) => (_c0.intValue(), _c1.doubleValue()) }
+      .toDF("row", "value")
       .withColumn("problemId", lit(DUMMY_PROBLEM_ID))
       .as[ConstraintBlock]
       .map{constraintBlock => (constraintBlock.row, constraintBlock.value) }


### PR DESCRIPTION
Add column names for loading budget data frames, or the flow for non-parallel Moo solver would fail with "sql" cannot find "row/value" error.