### PR TITLE
Improved gradient aggregator for very high dimensional dual vector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ allprojects {
     println ("Building with scala: ${scalaVersion}, spark: ${sparkVersion}")
 
     group = "com.linkedin.dualip"
-    
-    project.version = "1.1.3"
+
+    project.version = "1.2.0"
 
     repositories {
         mavenCentral()

--- a/dualip/src/main/scala/com/linkedin/dualip/solver/DistributedRegularizedObjective.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/solver/DistributedRegularizedObjective.scala
@@ -25,15 +25,17 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
- 
+
 package com.linkedin.dualip.solver
 
 import breeze.linalg.SparseVector
 import com.linkedin.dualip.blas.VectorOperations.toBSV
-import com.linkedin.dualip.util.SolverUtility
+import com.linkedin.dualip.util.{ArrayAggregation, SolverUtility}
 import com.linkedin.dualip.util.SolverUtility.SlackMetadata
 import com.twitter.algebird.Tuple3Semigroup
+import org.apache.log4j.Logger
 import org.apache.spark.sql.{Dataset, SparkSession}
+
 import scala.collection.mutable
 
 /**
@@ -57,12 +59,18 @@ case class PartialPrimalStats(ax: Array[(Int, Double)], cx: Double, xx: Double)
   *                                    cross over point is likely in the range between 100K and 1M, depends on the number of executors
   *                                    use false (default) for smaller dimensional problems
   *                                    use true for higher dimensional problems
+  * @param numLambdaPartitions       - used when enableHighDimOptimization=true, dense lambda vectors coming from executors are partitioned
+  *                                    for aggregation. The number of partitions should depend on aggregation parallelism and the dimensionality
+  *                                    of lambda. A good rule of thumb is to use a multiple of aggregation parallelism to ensure even load
+  *                                    but not too high to keep individual partition sizes large (e.g. 1000) for efficiency:
+  *                                    numLambdaPartitions \in [5*parallelism, dim(lambda)/1000]
   *
   * @param spark - spark session
   */
-abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: Double, enableHighDimOptimization: Boolean = false)
+abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: Double,
+  enableHighDimOptimization: Boolean = false, numLambdaPartitions: Option[Int] = None)
   (implicit spark: SparkSession) extends DualPrimalDifferentiableObjective with Serializable {
-  import spark.implicits._
+  import DistributedRegularizedObjective._
 
   override def dualDimensionality: Int = b.size
 
@@ -76,10 +84,13 @@ abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: D
   override def calculate(lambda: SparseVector[Double], log: mutable.Map[String, String], verbosity: Int): DualPrimalDifferentiableComputationResult = {
     // compute and aggregate gradients and objective value
     val partialGradients = getPrimalStats(lambda)
-    // choose between two implementations of gradient aggregator: they yield similar results
+    // choose between two implementations of gradient aggregator: they yield identical results
     // but different efficiency
     val (ax, cx, xx) = if(enableHighDimOptimization) {
-      twoStepGradientAggregator(partialGradients, lambda.size)
+      val partitions = numLambdaPartitions.getOrElse(DistributedRegularizedObjective.guessNumberOfLambdaPartitions(lambda.size))
+      require(partitions <= lambda.size,
+        s"Number of lambda aggregation partitions ($partitions) cannot be smaller than dimensionality of lambda ($lambda.size)")
+      fasterTwoStepGradientAggregator(partialGradients, lambda.size, partitions)
     } else {
       oneStepGradientAggregator(partialGradients)
     }
@@ -100,6 +111,7 @@ abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: D
     log += ("feasibility" -> f"${slackMetadata.feasibility}%.6e")
     log += ("λ(Ax-b)" -> f"${lambda dot gradient}%.6e")
     log += ("γ||x||^2/2" -> f"${xx * gamma / 2.0}%.6e")
+    log ++= extraLogging(axMinusB, lambda)
 
     if (verbosity >= 1) {
       log += ("max_pos_slack" -> f"${slackMetadata.maxPosSlack}%.6e")
@@ -108,6 +120,30 @@ abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: D
     }
     DualPrimalDifferentiableComputationResult(lambda, dualObjective, unregularizedDualObjective, gradient, primalObjective, axMinusB, slackMetadata)
   }
+
+  /**
+    * To add additional custom logging of Ax-b vector, one may want to log individual important constraints
+    * @param axMinusB - result of Ax-b computation
+    * @param lambda - current value of dual variable
+    * @return - the map to be added to the iteration log (key is column name, value is column value)
+    */
+  def extraLogging(axMinusB: SparseVector[Double], lambda: SparseVector[Double]): Map[String, String] = {
+    Map.empty
+  }
+
+  /**
+    * Method to implement in the child classes, it will be data/problem dependent
+    * @param lambda the dual variable
+    * @return
+    */
+  def getPrimalStats(lambda: SparseVector[Double]): Dataset[PartialPrimalStats]
+}
+
+/**
+  * Companion object with gradient aggregation implementation
+  */
+object DistributedRegularizedObjective {
+  val logger: Logger = Logger.getLogger(getClass)
 
   /**
     * Function to aggregate gradients from executors and send them to the driver.
@@ -144,7 +180,10 @@ abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: D
     * @param primalStats the partial primal statistics
     * @return
     */
-  def twoStepGradientAggregator(primalStats: Dataset[PartialPrimalStats], lambdaDim: Int): (Array[(Int, Double)], Double, Double) = {
+  @deprecated("Use fasterTwoStepGradientAggregator instead, this slower implementation is kept for reference")
+  def twoStepGradientAggregator(primalStats: Dataset[PartialPrimalStats], lambdaDim: Int)
+    (implicit sparkSession: SparkSession): (Array[(Int, Double)], Double, Double) = {
+    import sparkSession.implicits._
     val cxIndex = -1
     val xxIndex = -2
     val aggregate = primalStats.mapPartitions { partitionIterator =>
@@ -152,7 +191,7 @@ abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: D
       var cxAgg: Double = 0D
       var xxAgg: Double = 0D
       partitionIterator.foreach { stats =>
-        val ax = stats.ax.toArray
+        val ax = stats.ax
         var i = 0
         while( i < ax.length )
         {
@@ -177,9 +216,117 @@ abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: D
   }
 
   /**
-    * Method to implement in the child classes, it will be data/problem dependent
-    * @param lambda the dual variable
+    * Does aggregation in the following way:
+    * 1. each data partition performs aggregation of the gradients into java Array (dense)
+    * 2. we partition array into roughly equal subarrays
+    * 3. send subarrays to executors for aggregation, keyed by subarray id.
+    * 4. collect aggregated subarrays back to the driver and assemble into single array
+    *
+    * Example of performance on a real dataset compared to twoStepGradientAggregator:
+    *   lambdaDim: 1.3M
+    *   number of lambdas to aggregate: 4000
+    *   spark.default.parallelism = 200
+    *   executor memory: 16Gb (not a limiting factor for aggregation)
+    *   - Speedup of gradient computation tasks (that also perform initial gradient aggregation).
+    *     Median task time improved from 7s to 1s. The speedup of whole stage from 72s to 37s.
+    *   - Speedup of gradient aggregation tasks
+    *     Median task time improved from 17s to 1s. The speedup of whole stage from 35s to 8s.
+    *   - Speedup of the full gradient iteration from 120s to 40-50s. (e.g. >50% improvement).
+    *
+    * @param primalStats
+    * @param lambdaDim
+    * @param numPartitions
+    * @param sparkSession
     * @return
     */
-  def getPrimalStats(lambda: SparseVector[Double]): Dataset[PartialPrimalStats]
+  def fasterTwoStepGradientAggregator(primalStats: Dataset[PartialPrimalStats], lambdaDim: Int, numPartitions: Int)
+    (implicit sparkSession: SparkSession): (Array[(Int, Double)], Double, Double) = {
+    import sparkSession.implicits._
+    val aggregate = primalStats.mapPartitions { partitionIterator =>
+      val acxxAgg = new Array[Double](lambdaDim + 2)
+      partitionIterator.foreach { stats =>
+        val ax = stats.ax
+        var i = 0
+        while( i < ax.length )
+        {
+          val (axIndex, axValue) = ax(i)
+          acxxAgg(axIndex) += axValue
+          i += 1
+        }
+        acxxAgg(lambdaDim) += stats.cx
+        acxxAgg(lambdaDim + 1) += stats.xx
+      }
+      // partition array
+      val x = ArrayAggregation.partitionArray(acxxAgg, numPartitions)
+      x.iterator
+    }.rdd.reduceByKey(ArrayAggregation.aggregateArrays(_, _)).collect()
+
+    val ax = new Array[Double](lambdaDim)
+    var cx = 0.0
+    var xx = 0.0
+    aggregate.foreach { case (partition, subarray) =>
+      val (start, end) = ArrayAggregation.partitionBounds(lambdaDim + 2, numPartitions, partition)
+      if (partition == numPartitions - 1) {
+        // special case for last partition, as it holds 'xx' and 'cx' in the last two positions
+        cx = subarray(subarray.length - 2)
+        xx = subarray(subarray.length - 1)
+        System.arraycopy(subarray, 0, ax, start, subarray.length - 2)
+      } else {
+        System.arraycopy(subarray, 0, ax, start, subarray.length)
+      }
+    }
+    (ax.zipWithIndex.map{case (v, i) => (i, v)}, cx, xx)
+  }
+
+  /**
+    * Default number of lambda partitions per aggregation executor, used in guessNumberOfLambdaPartitions() method.
+    * Ideally number of partitions should be 4-10X the number of aggregation executors to guarantee
+    * even distribution of records.
+    *
+    * Users may override guessing logic by setting the total number of partitions manually.
+    */
+  val DefaultLambdaPartitionsPerExecutor: Int = 4
+  val MinimumRecommendedPartitionSize: Int = 100
+
+  /**
+    * Guess optimal number of partitions for lambda (gradient) vector used for aggregation.
+    * Important quantities to determine the optimal number of partitions:
+    *   lambdaDim - dimensionality of gradient
+    *   parallelism - how many "reducers" we use to aggregate gradients from our main tasks
+    *   numOfGradientTasks - number of partitions of the problem dataset, it determines the number of
+    *                        tasks that compute gradients and hence defines the number of gradient vectors
+    *                        that need aggregation.
+    *   numOfLambdaPartitions - partitioning of lambda/gradient for efficient aggregation, quantity that
+    *                           this function tries to guess.
+    *   partitionSize = lambdaDim/numOfLambdaPartitions
+    *
+    * There are two opposite effects that impact the optimal numOfLambdaPartitions and partitionSize.
+    *   - Larger partition size means less overhead in aggregation. Having partition size of ~1000 improved the
+    *     speed of aggregation 10X compared to partition of size 1 (one extreme)
+    *   - Fewer partitions prevent efficient parallelization of aggregation. I.e. having just 1 partition (another extreme)
+    *     would mean all gradient vectors are sent to the same executor effectively DDOS-ing it.
+    *
+    *  We recommend numOfLambdaPartitions to be (4-10)*parallelism, but make sure that the partition size is
+    *  at least (100-1000). Iif the second condtion is not met - it is a good reason to consider reducing parallelism.
+    *
+    *  The dependency of parameter tuning should be the following
+    *  1. DatasetSize + Complexity of projection ==> numOfGradientTasks: make sure data fits into memory and all the projections
+    *     are computed fast enough.
+    *  2. numOfGradientTasks + lambdaDim ==>  parallelism: Parallelism here is driven by I/O costs, how much data each
+    *     aggregation executor can accept fast enough.
+    *  3. lambdaDim + parallelism ==> numOfLambdaPartitions
+    *
+    * @param lambdaDim
+    * @param sparkSession
+    * @return
+    */
+  def guessNumberOfLambdaPartitions(lambdaDim: Int)(implicit sparkSession: SparkSession): Int = {
+    val parallelism = sparkSession.conf.get("spark.default.parallelism").toInt
+    // cannot have more partitions than the number of dimensions
+    val partitions = math.min(DefaultLambdaPartitionsPerExecutor * parallelism, lambdaDim)
+    val partitionSize = lambdaDim/partitions
+    if(partitionSize < MinimumRecommendedPartitionSize) logger.warn(s"Lambda partition size ${lambdaDim/partitions} is too small, consider reducing spark.default.parallelism")
+    logger.info(s"Gradient dimensionality is $lambdaDim, it is partitioned into $partitions subarrays for aggregation")
+    partitions
+  }
 }

--- a/dualip/src/main/scala/com/linkedin/dualip/util/ArrayAggregation.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/util/ArrayAggregation.scala
@@ -1,0 +1,116 @@
+/*
+ * BSD 2-CLAUSE LICENSE
+ *
+ * Copyright 2021 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+package com.linkedin.dualip.util
+
+import java.util
+
+/**
+  * Util methods for fast aggregation of very large arrays. Intended for very high dimensional lambdas.
+  * For example, 1M-dimensional. Each executor will likely produce dense vector with almost all dimensions.
+  * Standard approach where we convert gradients into (key, value) pairs and use spark aggregation is slow.
+  * This object provides methods to do array summation, as well as array partitioning to aggregate arrays
+  * in a distributed way (sending all arrays to the driver would kill driver I/O).
+  *
+  * Profiling on a single core (see ArrayAggregationTest) has the following results for
+  * aggregating 1000 arrays of 10,000 dimension:
+  * baseline:      56-58 sec
+  * this library:  1.2 sec (most of it is spark overhead, if the method is executed directly it only takes 0.03 sec).
+  *
+  * There is also an I/O win, arrays of doubles are stored with minimal overheads.
+  */
+object ArrayAggregation {
+  /**
+    * Aggregate two arrays of the same size by allocating new array and then looping over dimensions filling
+    * the sums. This is the fastest method that I found so far. Other alternatives that I also tried and
+    * that are much slower are:
+    *   - summation of Breeze Sparse/Dense vectors
+    *   - summation of maps (flattened representation)
+    *   - summation using scala collections
+    *
+    * Key differentiators:
+    *   - use of Array[Double] which is a wrapper of java double[]. It has special implementation for primitive types
+    *     that native scala collections do not support
+    *   - looping using while loop, scala functional transformations (zip, map etc) are much slower
+    * @param l
+    * @param r
+    * @return
+    */
+  def aggregateArrays(l: Array[Double], r: Array[Double]): Array[Double] = {
+    require(l.length == r.length, "Cannot aggregate arrays of different sizes")
+    val result = new Array[Double](l.size)
+    var i = 0
+    while(i < l.size){
+      result(i) = l(i) + r(i)
+      i += 1
+    }
+    result
+  }
+
+  /**
+    * Method to find [start, end) positions in the array of a given partition.
+    * Array is partitioned into roughly identical partitions, the length of a partition may differ by one.
+    * @param arrayLength
+    * @param numPartitions
+    * @param partition
+    * @return
+    */
+  def partitionBounds(arrayLength: Int, numPartitions: Int, partition: Int): (Int, Int) = {
+    require(partition < numPartitions, s"partition number cannot be larger than total number of partitions")
+    require(numPartitions <= arrayLength)
+    // some partitions will have size basePartitionSize and some basePartitionSize+1
+    // we will stack larger partitions in the beginning of the array
+    val basePartitionSize = arrayLength / numPartitions
+    val numLargerPartitions = arrayLength - basePartitionSize * numPartitions
+    // second term accounts for larger partitions stacked prior to partition in question
+    val startIndex = partition * basePartitionSize + math.min(partition, numLargerPartitions)
+    val partitionSize = if(partition < numLargerPartitions) {
+      basePartitionSize + 1
+    } else {
+      basePartitionSize
+    }
+    val endIndex = startIndex + partitionSize
+    (startIndex, endIndex)
+  }
+
+  /**
+    * Partitions array into numPartitions of almost equal size. Sizes differ at most by 1 because
+    * array size may not be divisible by numPartitions. All larger partitions go first.
+    * E.g. array of size 8 partitioned into 3will have subarrays of sizes 3, 2, 2
+    * @param data            - input array
+    * @param numPartitions   - num partitions
+    * @return                - tuples of (partitionNumber, sub-array)
+    */
+  def partitionArray(data: Array[Double], numPartitions: Int): Seq[(Int, Array[Double])] = {
+    require(numPartitions <= data.length)
+    (0 until numPartitions).map { partition =>
+      val (start, end) = partitionBounds(data.length, numPartitions, partition)
+      (partition, util.Arrays.copyOfRange(data, start, end))
+    }
+  }
+}

--- a/dualip/src/test/scala/com/linkedin/dualip/problem/MatchingSolverTest.scala
+++ b/dualip/src/test/scala/com/linkedin/dualip/problem/MatchingSolverTest.scala
@@ -77,7 +77,7 @@ class MatchingSolverTest {
     spark.sparkContext.setLogLevel("warn")
 
     val slateOptimizer: SlateOptimizer = new SingleSlotOptimizer(0, new GreedyProjection())
-    val f = new MatchingSolverDualObjectiveFunction(spark.createDataset(data), BSV(b), slateOptimizer, 1E-06, enableHighDimOptimization)
+    val f = new MatchingSolverDualObjectiveFunction(spark.createDataset(data), BSV(b), slateOptimizer, 1E-06, enableHighDimOptimization, None)
 
     val optimizer = new AcceleratedGradientDescent(maxIter = 100)
     val (lambda, value, _) = optimizer.maximize(f, BSV.fill(5)(0.1))
@@ -94,7 +94,7 @@ class MatchingSolverTest {
     spark.sparkContext.setLogLevel("warn")
 
     val slateOptimizer: SlateOptimizer = new SingleSlotOptimizer(0, new GreedyProjection())
-    val f = new MatchingSolverDualObjectiveFunction(spark.createDataset(data), BSV(b), slateOptimizer, 1E-06, enableHighDimOptimization)
+    val f = new MatchingSolverDualObjectiveFunction(spark.createDataset(data), BSV(b), slateOptimizer, 1E-06, enableHighDimOptimization, None)
     // compute value using calculate function
     val value = f.calculate(BSV(expectedLambda), mutable.Map.empty, 1)
 
@@ -117,7 +117,7 @@ class MatchingSolverTest {
 
     val gamma = 1E-3
     val slateOptimizer: SlateOptimizer = new SingleSlotOptimizer(gamma, new SimplexProjection())
-    val f = new MatchingSolverDualObjectiveFunction(spark.createDataset(data), BSV(b), slateOptimizer, gamma, enableHighDimOptimization)
+    val f = new MatchingSolverDualObjectiveFunction(spark.createDataset(data), BSV(b), slateOptimizer, gamma, enableHighDimOptimization, None)
 
     val primalUpperBound: Double = expectedPrimalUpperBound + 5 * gamma/2
     Assert.assertTrue(Math.abs(f.getPrimalUpperBound - primalUpperBound) < 0.01)
@@ -139,7 +139,7 @@ class MatchingSolverTest {
 
     val gamma = 1E-6
     val slateOptimizer: SlateOptimizer = new SingleSlotOptimizer(gamma, new BoxCutProjection(1000))
-    val f = new MatchingSolverDualObjectiveFunction(spark.createDataset(data), BSV(Array(0.7, 0.7, 0.7, 0.7, 0.7)), slateOptimizer, gamma, enableHighDimOptimization)
+    val f = new MatchingSolverDualObjectiveFunction(spark.createDataset(data), BSV(Array(0.7, 0.7, 0.7, 0.7, 0.7)), slateOptimizer, gamma, enableHighDimOptimization, None)
 
     val optimizer = new AcceleratedGradientDescent(maxIter = 200)
 

--- a/dualip/src/test/scala/com/linkedin/dualip/util/ArrayAggregationTest.scala
+++ b/dualip/src/test/scala/com/linkedin/dualip/util/ArrayAggregationTest.scala
@@ -1,0 +1,121 @@
+/*
+ * BSD 2-CLAUSE LICENSE
+ *
+ * Copyright 2021 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+package com.linkedin.dualip.util
+
+import com.linkedin.spark.common.lib.TestUtils
+import org.apache.spark.sql.{Dataset, SparkSession}
+import org.testng.Assert
+import org.testng.annotations.Test
+
+import scala.util.Random
+
+class ArrayAggregationTest {
+  import ArrayAggregation._
+  @Test
+  def testAggregateArrays(): Unit = {
+    val l = Array(0.1, 0.2, 0.0, 0.5)
+    val r = Array(0.3, 0.0, 0.0, 3.3)
+    val expectedResult = Array(0.4, 0.2, 0.0, 3.8)
+    val result = aggregateArrays(l, r)
+    Assert.assertEquals(result.toVector, expectedResult.toVector) // convert to scala vectors because java Array compares by reference
+  }
+
+  @Test(
+    expectedExceptions = Array(classOf[java.lang.IllegalArgumentException]),
+    expectedExceptionsMessageRegExp = ".*Cannot aggregate arrays of different sizes"
+  )
+  def testAggregateArraysWithException(): Unit = {
+    val l = Array(0.1, 0.2, 0.0)
+    val r = Array(0.3, 0.0, 0.0, 3.3)
+    aggregateArrays(l, r)
+  }
+
+  @Test
+  def testPartitionBounds(): Unit = {
+    // even split into partitions
+    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 2, partition = 1), (4,8))
+    // uneven split, larger partitions should be stacked first
+    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 3, partition = 0), (0,3))
+    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 3, partition = 1), (3,6))
+    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 3, partition = 2), (6,8))
+  }
+
+  @Test(
+    expectedExceptions = Array(classOf[java.lang.IllegalArgumentException])
+  )
+  def testPartitionBoundsWithException(): Unit = {
+    // requesting higher partition than total number of partitions
+    Assert.assertEquals(partitionBounds(arrayLength = 3, numPartitions = 2, partition = 2), (4,8))
+  }
+
+  @Test
+  def testPartitionArray(): Unit = {
+    val input = (0 until 90).map(_.toDouble)
+    // two variants of partitioning: evenly sized partititions and unevenly sized partitions
+    for(partitions <- Seq(10, 17)){
+      val out: Seq[(Int, Array[Double])] = partitionArray(input.toArray, partitions)
+      // check that we can assemble to the original input
+      val combinedOut: Seq[Double] = out.sortBy { case (partition, subarray) => partition }
+        .map { case (partition, subarray) => subarray }
+        .fold(Array[Double]())(_ ++ _).toSeq
+      Assert.assertEquals(combinedOut, input)
+    }
+  }
+
+  /**
+    * Profiling section, test is disabled. Generates large number of random arrays and aggregates
+    * them using naive spark approach and ArrayAggregation functions. Both methods are wrapped
+    * into a spark job to ensure fair overheads.
+    */
+  //@Test
+  def profileArraysAggregation(): Unit = {
+    implicit val spark: SparkSession = TestUtils.createSparkSession()
+    import spark.implicits._
+    val n = 1000  // number of arrays
+    val d = 10000 // array dimensionality
+    spark.sparkContext.setLogLevel("warn")
+
+    val data: Seq[Array[Double]] = (0 until n).map { _ =>
+      (0 until d).toArray.map(_ => Random.nextDouble())
+    }
+    val dataFlattened = data.flatMap(arr => arr.zipWithIndex.map { case (a,b) => (b,a)})
+    val datasetFlattened: Dataset[(Int, Double)] = spark.createDataset(dataFlattened)
+    val datasetOfArrays: Dataset[Array[Double]] = spark.createDataset(data)
+
+    println("Generated random data")
+    val t0 = System.currentTimeMillis()
+    datasetOfArrays.reduce(aggregateArrays(_, _))
+    val t1 = System.currentTimeMillis()
+    println(s"ArraysAggregation elapsed time: ${(t1 - t0)/1000.0} seconds")
+
+    datasetFlattened.rdd.reduceByKey(_ + _).collect()
+    val t2 = System.currentTimeMillis()
+    println(s"Naive spark elapsed time: ${(t2 - t1)/1000.0} seconds")
+  }
+}


### PR DESCRIPTION
High dimensional (e.g. ~1M) dual vectors were aggregated using sparse <Key, Value> representation. New implementation breaks dual down into blocks of dense Array<Double> subarrays that can be added very efficiently. The blocksize/number of blocks can be set manually or guessed based on dimensionality and spark parallelism settings.

Added code to insert custom columns into per-iteration logging.