### PR TITLE
Enabling SimplexInequality projectionType and designInequality constraints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 
     group = "com.linkedin.dualip"
 
-    project.version = "1.2.0"
+    project.version = "1.2.1"
 
     repositories {
         mavenCentral()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,8 +20,9 @@ This library was created by `Yao Pan
 <https://www.linkedin.com/in/kinjalbasu/>`_, `Rohan Ramanath
 <https://www.linkedin.com/in/rohanramanath/>`_, `Konstantin Salomatin
 <https://www.linkedin.com/in/ksalomatin/>`_, `Amol Ghoting
-<https://www.linkedin.com/in/amolghoting/>`_, and `Sathiya Keerthi
-<https://www.linkedin.com/in/sathiya-keerthi-selvaraj-ba963414/>`_ from LinkedIn.
+<https://www.linkedin.com/in/amolghoting/>`_, `Sathiya Keerthi
+<https://www.linkedin.com/in/sathiya-keerthi-selvaraj-ba963414/>`_, and `Miao Cheng
+<https://www.linkedin.com/in/miaoch/>`_ from LinkedIn.
 
 **Code available on** `GitHub 
 <https://github.com/linkedin/DuaLip>`_.

--- a/dualip/src/main/scala/com/linkedin/dualip/solver/DistributedRegularizedObjective.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/solver/DistributedRegularizedObjective.scala
@@ -79,9 +79,10 @@ abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: D
     * @param lambda   The variable (vector) being optimized
     * @param log      Key-value pairs used to store logging information for each iteration of the optimizer
     * @param verbosity  Control the logging level
+    * @param designInequality True if Ax <= b, false if Ax = b
     * @return
     */
-  override def calculate(lambda: SparseVector[Double], log: mutable.Map[String, String], verbosity: Int): DualPrimalDifferentiableComputationResult = {
+  override def calculate(lambda: SparseVector[Double], log: mutable.Map[String, String], verbosity: Int, designInequality: Boolean = true): DualPrimalDifferentiableComputationResult = {
     // compute and aggregate gradients and objective value
     val partialGradients = getPrimalStats(lambda)
     // choose between two implementations of gradient aggregator: they yield identical results
@@ -102,7 +103,7 @@ abstract class DistributedRegularizedObjective(b: SparseVector[Double], gamma: D
 
     // compute some extra values
     val primalObjective = cx +  xx * gamma / 2.0
-    val slackMetadata: SlackMetadata = SolverUtility.getSlack(lambda.toArray, axMinusB.toArray, b.toArray)
+    val slackMetadata: SlackMetadata = SolverUtility.getSlack(lambda.toArray, axMinusB.toArray, b.toArray, designInequality)
 
     // The sum of positive slacks, one of measures of constraints violation useful for logging
     val absoluteConstraintsViolation =  axMinusB.toArray.filter(_ > 0.0).sum

--- a/dualip/src/main/scala/com/linkedin/dualip/solver/DualPrimalDifferentiableObjective.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/solver/DualPrimalDifferentiableObjective.scala
@@ -106,9 +106,10 @@ trait DualPrimalDifferentiableObjective {
     * @param lambda   The variable (vector) being optimized
     * @param log      Key-value pairs used to store logging information for each iteration of the optimizer
     * @param verbosity  Control the logging level
+    * @param designInequality True if Ax <= b, false if Ax = b
     * @return
     */
-  def calculate(lambda: SparseVector[Double], log: mutable.Map[String, String], verbosity: Int): DualPrimalDifferentiableComputationResult
+  def calculate(lambda: SparseVector[Double], log: mutable.Map[String, String], verbosity: Int, designInequality: Boolean = true): DualPrimalDifferentiableComputationResult
 
   /**
     * The maximum value the primal formulation can take is pre-computed and stored.

--- a/dualip/src/main/scala/com/linkedin/dualip/solver/DualPrimalGradientMaximizerLoader.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/solver/DualPrimalGradientMaximizerLoader.scala
@@ -41,7 +41,7 @@ object DualPrimalGradientMaximizerLoader {
     val solver: DualPrimalGradientMaximizer = solverType match {
       case OptimizerType.LBFGSB => new LBFGSB(maxIter = maxIter, dualTolerance = dualTolerance, slackTolerance = slackTolerance)
       case OptimizerType.LBFGS => new LBFGS(alpha = alpha, maxIter = maxIter, dualTolerance = dualTolerance, slackTolerance = slackTolerance)
-      case OptimizerType.AGD => new AcceleratedGradientDescent(maxIter = maxIter, dualTolerance = dualTolerance, slackTolerance = slackTolerance)
+      case OptimizerType.AGD => new AcceleratedGradientDescent(maxIter = maxIter, dualTolerance = dualTolerance, slackTolerance = slackTolerance, designInequality = designInequality)
     }
     solver
   }
@@ -50,6 +50,7 @@ object DualPrimalGradientMaximizerLoader {
 /**
  * Union of optimizer parameters
  * @param solverType        Solver type
+ * @param designInequality  True if Ax <= b, false if Ax = b
  * @param alpha             LBFGS positivity contstraint relaxation
  * @param dualTolerance     Tolerance criteria for dual variable change
  * @param slackTolerance    Tolerance criteria for slack
@@ -57,6 +58,7 @@ object DualPrimalGradientMaximizerLoader {
  */
 case class DualPrimalGradientMaximizerParams(
   solverType: OptimizerType = OptimizerType.LBFGSB,
+  designInequality: Boolean = true,
   alpha: Double = 1E-6,
   dualTolerance: Double = 1E-8,
   slackTolerance: Double = 5E-6,
@@ -72,6 +74,7 @@ object DualPrimalGradientMaximizerParamsParser {
       override def errorOnUnknownArgument = false
       val namespace = "optimizer"
       opt[String](s"$namespace.solverType") required() action { (x, c) => c.copy(solverType = OptimizerType.withName(x)) }
+      opt[Boolean](s"$namespace.designInequality") optional() action { (x, c) => c.copy(designInequality = x) }
       opt[Double](s"$namespace.alpha") optional() action { (x, c) => c.copy(alpha = x) }
       opt[Double](s"$namespace.dualTolerance") required() action { (x, c) => c.copy(dualTolerance = x) }
       opt[Double](s"$namespace.slackTolerance") required() action { (x, c) => c.copy(slackTolerance = x) }

--- a/dualip/src/main/scala/com/linkedin/dualip/solver/MooDistributedRegularizedObjective.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/solver/MooDistributedRegularizedObjective.scala
@@ -60,9 +60,10 @@ abstract class MooDistributedRegularizedObjective(b: SparseVector[Double], gamma
     * @param lambda   The variable (vector) being optimized
     * @param log      Key-value pairs used to store logging information for each iteration of the optimizer
     * @param verbosity  Control the logging level
+    * @param designInequality True if Ax <= b, false if Ax = b
     * @return
     */
-  override def calculate(lambda: SparseVector[Double], log: mutable.Map[String, String], verbosity: Int): DualPrimalDifferentiableComputationResult = {
+  override def calculate(lambda: SparseVector[Double], log: mutable.Map[String, String], verbosity: Int, designInequality: Boolean = true): DualPrimalDifferentiableComputationResult = {
     // compute and aggregate gradients and objective value
     val partialGradients = getPrimalStats(lambda)
     // choose between two implementations of gradient aggregator: they yield similar results but different efficiency
@@ -79,7 +80,7 @@ abstract class MooDistributedRegularizedObjective(b: SparseVector[Double], gamma
 
     // compute some extra values, i.e. the primal objective and slack metadata
     val primalObjective = cx +  xx * gamma / 2.0
-    val slackMetadata: SlackMetadata = SolverUtility.getSlack(lambda.toArray, axMinusB.toArray, b.toArray)
+    val slackMetadata: SlackMetadata = SolverUtility.getSlack(lambda.toArray, axMinusB.toArray, b.toArray, designInequality)
 
     // The sum of positive slacks, one of measures of constraints violation useful for logging
     val absoluteConstraintsViolation =  axMinusB.toArray.filter(_ > 0.0).sum

--- a/dualip/src/main/scala/com/linkedin/dualip/solver/ParallelLPSolverDriver.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/solver/ParallelLPSolverDriver.scala
@@ -86,7 +86,7 @@ object ParallelLPSolverDriver {
       }.toDF("problemId", "logList", "dualList", "violationList")
 
       resultsDS
-        .repartition(10)
+        .repartition(1000)
         .write
         .format(driverParams.outputFormat.toString)
         .mode(SaveMode.Overwrite)

--- a/dualip/src/main/scala/com/linkedin/dualip/util/SolverUtility.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/util/SolverUtility.scala
@@ -44,19 +44,26 @@ object SolverUtility {
     * @param lambda   : vector lambda
     * @param r        : vector ax-b
     * @param b        : vector b
+    * @param designInequality : True if Ax <= b, false if Ax = b
     * @return
     */
-  def getSlack(lambda: Array[Double], r: Array[Double], b: Array[Double]): SlackMetadata = {
+  def getSlack(lambda: Array[Double], r: Array[Double], b: Array[Double], designInequality: Boolean = true): SlackMetadata = {
     var j = 0
     val res = Array.ofDim[Double](lambda.length)
     var maxPosSlack: Double = Double.NegativeInfinity
     var maxZeroSlack: Double = Double.NegativeInfinity
     var feasibility: Double = Double.NegativeInfinity
     while (j < lambda.length) {
-      if (lambda(j) == 0) {
-        res(j) = Math.max(r(j), 0)/(1 + Math.abs(b(j)))
-        maxZeroSlack = Math.max(maxZeroSlack, res(j))
-      } else {
+      if (designInequality) {
+        if (lambda(j) == 0) {
+          res(j) = Math.max(r(j), 0)/(1 + Math.abs(b(j)))
+          maxZeroSlack = Math.max(maxZeroSlack, res(j))
+        } else {
+          res(j) = Math.abs(r(j))/(1 + Math.abs(b(j)))
+          maxPosSlack = Math.max(maxPosSlack, res(j))
+        }
+      }
+      else {
         res(j) = Math.abs(r(j))/(1 + Math.abs(b(j)))
         maxPosSlack = Math.max(maxPosSlack, res(j))
       }

--- a/dualip/src/test/scala/com/linkedin/dualip/solver/Objectives.scala
+++ b/dualip/src/test/scala/com/linkedin/dualip/solver/Objectives.scala
@@ -40,7 +40,7 @@ import scala.collection.mutable
 class SimpleObjective() extends DualPrimalDifferentiableObjective {
   override def dualDimensionality: Int = 2
 
-  override def calculate(lambda: BSV[Double], log: mutable.Map[String, String]=null, verbosity: Int = 1): DualPrimalDifferentiableComputationResult = {
+  override def calculate(lambda: BSV[Double], log: mutable.Map[String, String]=null, verbosity: Int = 1, designInequality: Boolean = true): DualPrimalDifferentiableComputationResult = {
     val Array(x,y) = lambda.toArray
     val obj = -(x - 3.0)*(x - 3.0) - (y + 5.0)*(y + 5.0)
     val grad = Array(-2.0 * (x - 3.0), -2.0 * (y + 5.0))
@@ -60,7 +60,7 @@ class SimpleObjective() extends DualPrimalDifferentiableObjective {
 class RosenbrockObjective(val shift: Double = 0.0) extends DualPrimalDifferentiableObjective {
   override def dualDimensionality: Int = 2
 
-  override def calculate(lambda: BSV[Double], log: mutable.Map[String, String]=null, verbosity: Int = 1): DualPrimalDifferentiableComputationResult = {
+  override def calculate(lambda: BSV[Double], log: mutable.Map[String, String]=null, verbosity: Int = 1, designInequality: Boolean = true): DualPrimalDifferentiableComputationResult = {
     val Array(_x,_y) = lambda.toArray
     val x = _x - shift
     val y = _y - shift


### PR DESCRIPTION
- Added SimplexInequality as a new projection type in MooSolver.scala.
- Added designInequality (True if Ax <= b, false if Ax = b) as a new parameter to AcceleratedGradientDescent.scala.
- Added designInequality parameter to DistributedRegularizedObjective.scala.
- Added designInequality paramter to DualPrimalDifferentiableObjective.scala.
- Added designInequality parameter to MooDistributedRegularizedObjective.scala.
- Added designInequality parameter to SolverUtility.scala.
- Added designInequality parameter to Objectives.scala unit testing file.
- Changed the default repartition size to be 1000 in ParallelLPSolverDriver.scala to cater to extreme size of data.