### PR TITLE
Fixed performance bottleneck of parallel solver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 
     group = "com.linkedin.dualip"
 
-    project.version = "2.1.1"
+    project.version = "2.1.2"
 
     repositories {
         mavenCentral()

--- a/dualip/src/main/scala/com/linkedin/dualip/util/UnifiedDataStructure.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/util/UnifiedDataStructure.scala
@@ -25,7 +25,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
- 
+
 package com.linkedin.dualip.util
 
 import org.apache.spark.sql.{Dataset, Encoder}
@@ -36,12 +36,12 @@ import scala.reflect.ClassTag
  */
 trait MapReduceCollectionWrapper[A] {
   val value: Object
-  def map[B: ClassTag](op: A => B)(implicit encoder: Encoder[B]): MapReduceCollectionWrapper[B]
+  def map[B: ClassTag](op: A => B, encoder: Encoder[B]): MapReduceCollectionWrapper[B]
   def reduce(op: (A, A) => A): A
 }
 
 case class MapReduceArray[A](value: Array[A]) extends MapReduceCollectionWrapper[A] {
-  override def map[B: ClassTag](op: A => B)(implicit encoder: Encoder[B]): MapReduceArray[B] = {
+  override def map[B: ClassTag](op: A => B, encoder: Encoder[B]): MapReduceArray[B] = {
     MapReduceArray[B](value.map(op))
   }
   override def reduce(op: (A, A) => A ): A = {
@@ -50,8 +50,8 @@ case class MapReduceArray[A](value: Array[A]) extends MapReduceCollectionWrapper
 }
 
 case class MapReduceDataset[A](value: Dataset[A]) extends MapReduceCollectionWrapper[A] {
-  override def map[B: ClassTag](op: A => B)(implicit encoder: Encoder[B]): MapReduceDataset[B] = {
-    MapReduceDataset[B](value.map(op))
+  override def map[B: ClassTag](op: A => B, encoder: Encoder[B]): MapReduceDataset[B] = {
+    MapReduceDataset[B](value.map(op)(encoder))
   }
   override def reduce(op: (A, A) => A ): A = {
     value.reduce(op)


### PR DESCRIPTION
An auxiliary Encoder objects initialization took a long time, effectively becoming a bottleneck of parallel solver (based on IntelliJ profiler). The object is initialized dynamically (via spark implicits) every time the aggregation or transformation is performed on the problem data, which means several times per algorithm iteration. For a single distributed problem it is not an issue. For parallel solving of millions of small problems it is re-created unnecessarily. The solution is to recylce a small set of encoder object (via static references). Note: the encoder is not even necessary for parallel solver, but it is hard to get around the API requirements made for distributed solver, so we pass the encoder anyway. It would be nice to refactor the code in such a way that unnecessary encoder object is not created.

Attached profiler screenshot shows that call to org.apache.spark.sql.SQLImplicits.newProductEncoder(TypeTags$TypeTag) takes 97.68% of its parent call (primal variable computation).

Results:
For 200 executors, 1M dataset
New run: 1h 15m
Old run: 1d 15h 15m

The results suggest ~30X  improvement, may not be directly comparable due to cluster conditions variability.
<img width="823" alt="Screen Shot 2022-02-15 at 1 14 16 PM" src="https://user-images.githubusercontent.com/95897982/156731090-f1fc48a2-1b83-4ea9-b969-80f6bc4d6512.png">