### PR TITLE
Add Moo Primal Saving Functionality and Bump Minor Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 
     group = "com.linkedin.dualip"
 
-    project.version = "2.3.4"
+    project.version = "2.4.0"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Implemented the `getPrimalForSaving` method for `MooDualObjectiveFunction` in `MooSolver.scala`

**Changes:**
- Added `getPrimalForSaving` in `MooSolverDualObjectiveFunction` class
- Added `encoderIdPrimal` for appropriate mapping of the result from `getPrimal`
- Bumped minor version due to the added feature (2.3.4 -> 2.4.0)