### PR TITLE
Add Customizable Box Cut Upper Bound Support for MooSolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 
     group = "com.linkedin.dualip"
 
-    project.version = "2.5.5"
+    project.version = "2.6.2"
 
     repositories {
         mavenCentral()

--- a/dualip/src/main/scala/com/linkedin/dualip/projection/BoxCutProjection.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/projection/BoxCutProjection.scala
@@ -34,9 +34,15 @@ import com.linkedin.dualip.util.ProjectionType.BoxCut
 
 
 /**
- * Boxed simplex projection
- *
- */
+  * Box Cut projection, \sum_j x_j = d or \sum_j x_j <= d along with 0 <= x_j <= 1
+  *
+  * @param maxIter: bounds the number of iterations of Wolfe's algorithm
+  * @param inequality: makes the constraint \sum_j x_j <= d when true
+  *
+  * Note that the upper bound d is set through metadata, for example:
+  * val metadata: Map[String, Double] = Map[String, Double]("boxCut" -> 3) -- d = 3 in this case
+  *
+  */
 class BoxCutProjection(maxIter: Int, inequality: Boolean = false) extends PolytopeProjection(polytope = null, maxIter) with Serializable {
 
   val unitBoxProjection = new UnitBoxProjection()

--- a/dualip/src/main/scala/com/linkedin/dualip/solver/ParallelLPSolverDriver.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/solver/ParallelLPSolverDriver.scala
@@ -75,7 +75,7 @@ object ParallelLPSolverDriver {
 
       val resultsDS = setOfProblems.map { case (problemId, data, budget) =>
         val objective: DualPrimalDifferentiableObjective =
-          new MooSolverDualObjectiveFunction(data, toBSV(budget, budget.length), driverParams.gamma, driverParams.projectionType)
+          new MooSolverDualObjectiveFunction(data, toBSV(budget, budget.length), driverParams.gamma, driverParams.projectionType, driverParams.boxCutUpperBound)
         // initialize lambda: first try custom logic of the objective, then driver-generic lambda loader, finally initialize with zeros
         val initialLambda: BSV[Double] = objective.getInitialLambda.getOrElse(
           getInitialLambda(driverParams.initialLambdaPath, driverParams.initialLambdaFormat, objective.dualDimensionality)


### PR DESCRIPTION
- Added a new applyWithCustomizedBoxCut function in MooSolver.scala to pass the customized upper bound for box cut projection into MooSolverDualObjectiveFunction initialization;
- Added a new param boxCutUpperBound in all the relevant functions in MooSolver.scala;
- Modified APIs LPSolverDriver.scala and ParallelLPSolverDriver.scala to pass through the boxCutUpperBound param;
- Added clear explanation in the BoxCutProjection.scala script to describe the functions of box cut projection.