### PR TITLE
order of local and global budgets got reversed in the initialization of constrained matching solver, fixing that issue

### DIFF
--- a/dualip/src/main/scala/com/linkedin/dualip/problem/ConstrainedMatchingSolver.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/problem/ConstrainedMatchingSolver.scala
@@ -36,7 +36,7 @@ class ConstrainedMatchingSolverDualObjectiveFunction(
   enableHighDimOptimization: Boolean,
   numLambdaPartitions: Option[Int]
 )(implicit spark: SparkSession) extends
-  DistributedRegularizedObjective(BSV(budget.budgetLocal.toArray ++ budget.budgetGlobal.toArray), gamma,
+  DistributedRegularizedObjective(BSV(budget.budgetGlobal.toArray ++ budget.budgetLocal.toArray), gamma,
     enableHighDimOptimization, numLambdaPartitions) with Serializable {
 
   import spark.implicits._

--- a/dualip/src/test/scala/com/linkedin/dualip/problem/ConstrainedMatchingSolverTest.scala
+++ b/dualip/src/test/scala/com/linkedin/dualip/problem/ConstrainedMatchingSolverTest.scala
@@ -83,7 +83,7 @@ class ConstrainedMatchingSolverTest {
   val initialValueDualsBSV: BSV[Double] = BSV(initialValuesGlobalDuals.toArray ++ initialValuesLocalDuals.toArray)
 
   // expected values for this problem were computed with SCS
-  val expectedDualObjective: Double = -32.470503
+  val expectedDualObjective: Double = -34.81553
   val localDuals: BSV[Double] = BSV(Array(3.991200, 2.252802))
   val globalDuals: BSV[Double] = BSV(Array(2.320209))
   val duals: ConstrainedMatchingDualsBSV = ConstrainedMatchingDualsBSV(localDuals, globalDuals)


### PR DESCRIPTION
## Summary 
The order of local and global budgets got reversed in the initialization of the constrained matching solver. We fix this issue in this PR.

## Tests
All unit tests passed.