### PR TITLE
Fix bug in twoStepGradientAggregator method.

### DIFF
--- a/dualip/src/main/scala/com/linkedin/dualip/util/ArrayAggregation.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/util/ArrayAggregation.scala
@@ -49,9 +49,9 @@ object ArrayAggregation {
     * Method to find [start, end) positions in the array of a given partition.
     * Array is partitioned into roughly identical partitions, the length of a partition may differ by one.
     *
-    * @param arrayLength
-    * @param numPartitions
-    * @param partition
+    * @param arrayLength   - length of the array whose slicing positions are being considered
+    * @param numPartitions - the total number of partitions that the array of length arrayLength is stored in
+    * @param partition     - the index value for the partitions that can assume values from 0 to numPartitions - 1
     * @return
     */
   def partitionBounds(arrayLength: Int, numPartitions: Int, partition: Int): (Int, Int) = {
@@ -61,12 +61,16 @@ object ArrayAggregation {
     // we will stack larger partitions in the beginning of the array
     val basePartitionSize = arrayLength / numPartitions
     val numLargerPartitions = arrayLength - basePartitionSize * numPartitions
-    // second term accounts for larger partitions stacked prior to partition in question
-    val startIndex = partition * basePartitionSize + math.min(partition, numLargerPartitions)
+
     val partitionSize = if (partition < numLargerPartitions) {
       basePartitionSize + 1
     } else {
       basePartitionSize
+    }
+    val startIndex = if (partition < numLargerPartitions) {
+      partition * partitionSize
+    } else {
+      numLargerPartitions + partition * partitionSize
     }
     val endIndex = startIndex + partitionSize
     (startIndex, endIndex)

--- a/dualip/src/test/scala/com/linkedin/dualip/util/ArrayAggregationTest.scala
+++ b/dualip/src/test/scala/com/linkedin/dualip/util/ArrayAggregationTest.scala
@@ -1,5 +1,6 @@
 package com.linkedin.dualip.util
 
+import com.linkedin.dualip.objective.distributedobjective.DistributedRegularizedObjective.accumulateSufficientStatistics
 import com.linkedin.spark.common.lib.TestUtils
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.testng.Assert
@@ -31,11 +32,13 @@ class ArrayAggregationTest {
   @Test
   def testPartitionBounds(): Unit = {
     // even split into partitions
-    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 2, partition = 1), (4,8))
+    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 2, partition = 1), (4, 8))
     // uneven split, larger partitions should be stacked first
-    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 3, partition = 0), (0,3))
-    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 3, partition = 1), (3,6))
-    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 3, partition = 2), (6,8))
+    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 3, partition = 0), (0, 3))
+    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 3, partition = 1), (3, 6))
+    Assert.assertEquals(partitionBounds(arrayLength = 8, numPartitions = 3, partition = 2), (6, 8))
+    Assert.assertEquals(partitionBounds(arrayLength = 40, numPartitions = 20, partition = 10), (20, 22))
+    Assert.assertEquals(partitionBounds(arrayLength = 40, numPartitions = 38, partition = 37), (39, 40))
   }
 
   @Test(


### PR DESCRIPTION
The existing implementation of the `twoStepGradientAggregator` method fails when the number of partitions approaches the dimension of the duals. In such a case, the objective and the squared primals are stored in the last two partitions. (The original code assumed that the objective and squared primals would both be stored in the last partition.)

We fix this failure by carefully adding clauses in the code that accounts for this corner case.

Test: `./gradlew build` succeeds.