### PR TITLE
Bugfix for PolytopeProjection.checkOptimality.

### DIFF
--- a/dualip/build.gradle
+++ b/dualip/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 
   testImplementation("org.apache.spark:spark-core_${scalaVersion}:${sparkVersion}")
   testImplementation("org.apache.spark:spark-sql_${scalaVersion}:${sparkVersion}")
+  testImplementation("org.scalatest:scalatest_${scalaVersion}:${sparkVersion}")
   testImplementation("org.testng:testng:6.10")
 }
 

--- a/dualip/src/main/scala/com/linkedin/dualip/driver/LPSolverDriver.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/driver/LPSolverDriver.scala
@@ -8,8 +8,8 @@ import com.linkedin.dualip.util.DataFormat.DataFormat
 import com.linkedin.dualip.util.IOUtility.{printCommandLineArgs, readDataFrame, saveDataFrame, saveLog}
 import com.linkedin.dualip.util.ProjectionType.{Greedy, ProjectionType}
 import com.linkedin.dualip.util.SolverUtility
-import com.linkedin.optimization.util.VectorOperations
-import com.linkedin.optimization.util.VectorOperations.toBSV
+import com.linkedin.dualip.util.VectorOperations
+import com.linkedin.dualip.util.VectorOperations.toBSV
 import org.apache.log4j.Logger
 import org.apache.spark.sql.{DataFrame, SparkSession}
 

--- a/dualip/src/main/scala/com/linkedin/dualip/driver/ParallelLPSolverDriver.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/driver/ParallelLPSolverDriver.scala
@@ -7,7 +7,7 @@ import com.linkedin.dualip.maximizer.{DualPrimalMaximizer, DualPrimalMaximizerLo
 import com.linkedin.dualip.objective.DualPrimalObjective
 import com.linkedin.dualip.problem.{MooSolverDualObjectiveFunction, ParallelMooSolverDualObjectiveFunction}
 import com.linkedin.dualip.util.{InputPathParamsParser, MapReduceArray}
-import com.linkedin.optimization.util.VectorOperations.toBSV
+import com.linkedin.dualip.util.VectorOperations.toBSV
 import org.apache.spark.sql.{Dataset, SaveMode, SparkSession}
 
 /**

--- a/dualip/src/main/scala/com/linkedin/dualip/objective/distributedobjective/DistributedRegularizedObjective.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/objective/distributedobjective/DistributedRegularizedObjective.scala
@@ -4,7 +4,7 @@ import breeze.linalg.SparseVector
 import com.linkedin.dualip.objective.{DualPrimalComputationResult, DualPrimalObjective, PartialPrimalStats}
 import com.linkedin.dualip.util.SolverUtility.SlackMetadata
 import com.linkedin.dualip.util.{ArrayAggregation, SolverUtility}
-import com.linkedin.optimization.util.VectorOperations.toBSV
+import com.linkedin.dualip.util.VectorOperations.toBSV
 import com.twitter.algebird.Tuple3Semigroup
 import org.apache.log4j.Logger
 import org.apache.spark.sql.{Dataset, SparkSession}

--- a/dualip/src/main/scala/com/linkedin/dualip/objective/distributedobjective/MooDistributedRegularizedObjective.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/objective/distributedobjective/MooDistributedRegularizedObjective.scala
@@ -4,7 +4,7 @@ import breeze.linalg.SparseVector
 import com.linkedin.dualip.objective.{DualPrimalComputationResult, DualPrimalObjective, PartialPrimalStats}
 import com.linkedin.dualip.util.SolverUtility.SlackMetadata
 import com.linkedin.dualip.util.{MapReduceCollectionWrapper, SolverUtility}
-import com.linkedin.optimization.util.VectorOperations.toBSV
+import com.linkedin.dualip.util.VectorOperations.toBSV
 import com.twitter.algebird.Tuple3Semigroup
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.{Dataset, Encoder, SparkSession}

--- a/dualip/src/main/scala/com/linkedin/dualip/problem/ConstrainedMatchingSolver.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/problem/ConstrainedMatchingSolver.scala
@@ -9,7 +9,7 @@ import com.linkedin.dualip.slate.{ConstrainedMatchingSlateComposer, Slate}
 import com.linkedin.dualip.util.DataFormat.DataFormat
 import com.linkedin.dualip.util.ProjectionType._
 import com.linkedin.dualip.util.{DataFormat, IOUtility}
-import com.linkedin.optimization.util.VectorOperations.toBSV
+import com.linkedin.dualip.util.VectorOperations.toBSV
 import com.twitter.algebird.{Max, Tuple5Semigroup}
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}

--- a/dualip/src/main/scala/com/linkedin/dualip/problem/MatchingSlateSolver.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/problem/MatchingSlateSolver.scala
@@ -8,7 +8,7 @@ import com.linkedin.dualip.projection.{BoxCutProjection, GreedyProjection, Simpl
 import com.linkedin.dualip.slate.{SecondPriceAuctionSlateComposer, SingleSlotComposer, Slate, SlateComposer}
 import com.linkedin.dualip.util.ProjectionType._
 import com.linkedin.dualip.util.{IOUtility, InputPathParamsParser, InputPaths}
-import com.linkedin.optimization.util.VectorOperations.toBSV
+import com.linkedin.dualip.util.VectorOperations.toBSV
 import com.twitter.algebird.{Max, Tuple5Semigroup}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.functions.{col, lit}

--- a/dualip/src/main/scala/com/linkedin/dualip/problem/MooSolver.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/problem/MooSolver.scala
@@ -7,7 +7,7 @@ import com.linkedin.dualip.objective.{DualPrimalObjective, DualPrimalObjectiveLo
 import com.linkedin.dualip.projection.{BoxCutProjection, Projection, SimplexProjection, UnitBoxProjection}
 import com.linkedin.dualip.util.ProjectionType._
 import com.linkedin.dualip.util._
-import com.linkedin.optimization.util.VectorOperations.toBSV
+import com.linkedin.dualip.util.VectorOperations.toBSV
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.functions.lit

--- a/dualip/src/main/scala/com/linkedin/dualip/util/VectorOperations.scala
+++ b/dualip/src/main/scala/com/linkedin/dualip/util/VectorOperations.scala
@@ -1,4 +1,4 @@
-package com.linkedin.optimization.util
+package com.linkedin.dualip.util
 
 import breeze.linalg.{SparseVector => BSV}
 

--- a/dualip/src/test/scala/com/linkedin/dualip/blas/VectorOperationsTest.scala
+++ b/dualip/src/test/scala/com/linkedin/dualip/blas/VectorOperationsTest.scala
@@ -1,7 +1,7 @@
 package com.linkedin.dualip.blas
 
 import breeze.linalg.{SparseVector => BSV}
-import com.linkedin.optimization.util.VectorOperations.dot
+import com.linkedin.dualip.util.VectorOperations.dot
 import org.testng.Assert
 import org.testng.annotations.Test
 

--- a/dualip/src/test/scala/com/linkedin/dualip/projection/BoxCutProjectionTest.scala
+++ b/dualip/src/test/scala/com/linkedin/dualip/projection/BoxCutProjectionTest.scala
@@ -2,7 +2,7 @@ package com.linkedin.dualip.projection
 
 import breeze.linalg.{SparseVector => BSV}
 import com.linkedin.dualip.projection.PolytopeProjectionTest.tol
-import com.linkedin.optimization.util.VectorOperations.dot
+import com.linkedin.dualip.util.VectorOperations.dot
 import org.testng.Assert
 import org.testng.annotations.Test
 


### PR DESCRIPTION
## Summary
This PR provides a fix for the singular matrix error that was showing up. (We also take the opportunity to fix some incorrect imports.)

## Details
The error occurs when we call `BoxCutProjection.project()` on a particular vector `v`. At some point in the Wolfe algorithm, the corral is `S = {s1, s2}`, and the optimal solution so far (`x`) is a convex combination of the two. In the next iteration of the algorithm, it selected `s1` as the candidate vertex to add to the corral.

What should have happened: we should have detected that we reached optimality and return `x` as the solution.

What actually happened: `checkOptimality()` concluded that we had not reached optimality, and so incorrectly added `s1` again to the corral to give `S = {s1, s2, s1}`. This then resulted in the singular matrix error later in `AffineMinimizer()` due to `s1` appearing twice in the corral.

Fix: Mathematically, the optimality check is `s^T s - s^T v <= 0`. Because of numerical precision we loosened it to `s^T s - s^T v <= tolerance * s^T s`. However, in this case `s` had very small norm, resulting in the check being overly strict. We loosen the RHS of the check to account for this case.

## Testing

Local unit tests pass; local `./gradlew build` succeeds.