### PR TITLE
Fix OOM caused by sparse matrix splitting

### DIFF
--- a/src/dualip/utils/sparse_utils.py
+++ b/src/dualip/utils/sparse_utils.py
@@ -285,9 +285,9 @@ def split_csc_by_cols(M: torch.Tensor, split_sizes: List[int]) -> List[torch.Ten
         end_nnz = int(col_ptr[end_col].item())
 
         # slice out the per-block CSC arrays
-        sub_col_ptr = col_ptr[start_col : (end_col + 1)] - col_ptr[start_col]
-        sub_row_idx = row_idx[start_nnz:end_nnz]
-        sub_vals = vals[start_nnz:end_nnz]
+        sub_col_ptr = (col_ptr[start_col : (end_col + 1)] - col_ptr[start_col]).clone()
+        sub_row_idx = row_idx[start_nnz:end_nnz].clone()
+        sub_vals = vals[start_nnz:end_nnz].clone()
 
         # build the sub‐matrix
         M_block = torch.sparse_csc_tensor(sub_col_ptr, sub_row_idx, sub_vals, size=(m, width))


### PR DESCRIPTION
This PR fixes an OOM error in the distributed solver setup.

The issue was caused by the data splitting logic, which created tensor slices as views of the full tensors when constructing the per-rank input arguments. As a result, each sliced tensor still referenced the underlying full tensor storage.

During torch.distributed.scatter_object_list, these objects are serialized and materialized as tensors on the process group device (CUDA). Because the slices referenced the full tensor storage, PyTorch effectively attempted to serialize buffers corresponding to the entire original tensors, leading to very large temporary allocations and triggering a GPU OOM.

The fix clones the tensor slices before constructing the per-rank arguments. This creates independent tensors with storage proportional to the slice size, ensuring that only the required data is serialized and transferred during scatter_object_list.

Without clone:
rank 0 <class 'dualip.objectives.matching.MatchingInputArgs'> 22.83929910324514 GiB serialized
rank 1 <class 'dualip.objectives.matching.MatchingInputArgs'> 22.83929909300059 GiB serialized
rank 2 <class 'dualip.objectives.matching.MatchingInputArgs'> 22.83929909300059 GiB serialized
rank 3 <class 'dualip.objectives.matching.MatchingInputArgs'> 22.83929909300059 GiB serialized
Total: 24.30635734461248 GiB

with clone: 
rank 0 <class 'dualip.objectives.matching.MatchingInputArgs'> 6.076507980003953 GiB serialized
rank 1 <class 'dualip.objectives.matching.MatchingInputArgs'> 6.076217452995479 GiB serialized
rank 2 <class 'dualip.objectives.matching.MatchingInputArgs'> 6.076679172925651 GiB serialized
rank 3 <class 'dualip.objectives.matching.MatchingInputArgs'> 6.076554807834327 GiB serialized
Total: 24.306357331573963 GiB

