### PR TITLE
Move transfer_tensors_to_device into utils/dist_utils

### DIFF
--- a/src/dualip/run_solver.py
+++ b/src/dualip/run_solver.py
@@ -1,4 +1,3 @@
-from dataclasses import fields
 from typing import Optional
 
 import torch
@@ -11,34 +10,8 @@ from dualip.objectives.matching import (
 from dualip.objectives.miplib import MIPLIB2017ObjectiveFunction
 from dualip.optimizers.agd import AcceleratedGradientDescent, SolverResult
 from dualip.types import ComputeArgs, ObjectiveArgs, SolverArgs
+from dualip.utils.dist_utils import transfer_tensors_to_device
 from dualip.utils.mlflow_utils import MLflowConfig, log_hyperparameters, mlflow_run_context
-
-
-def transfer_tensors_to_device(input_args: BaseInputArgs, device: str):
-    """
-    Transfer all tensor fields in input_args to the specified device.
-
-    Args:
-        input_args: The input arguments object
-        device: The target device (e.g., 'cuda:0', 'cpu')
-
-    Returns:
-        A new instance of input_args with all tensors transferred to device
-    """
-    # Get all field names from the dataclass
-    field_names = [field.name for field in fields(input_args)]
-
-    # Create a dictionary of field values with tensors transferred to device
-    field_values = {}
-    for field_name in field_names:
-        value = getattr(input_args, field_name)
-        if isinstance(value, torch.Tensor):
-            field_values[field_name] = value.to(device)
-        else:
-            field_values[field_name] = value
-
-    # Create a new instance of the same class with transferred tensors
-    return type(input_args)(**field_values)
 
 
 def build_objective(

--- a/src/dualip/utils/dist_utils.py
+++ b/src/dualip/utils/dist_utils.py
@@ -1,9 +1,32 @@
 from collections import defaultdict
+from dataclasses import fields
 
 import torch
 
+from dualip.objectives.base import BaseInputArgs
 from dualip.projections.base import ProjectionEntry
 from dualip.utils.sparse_utils import split_csc_by_cols
+
+
+def transfer_tensors_to_device(input_args: BaseInputArgs, device: str):
+    """
+    Transfer all tensor fields in input_args to the specified device.
+
+    Args:
+        input_args: The input arguments dataclass.
+        device: The target device (e.g., 'cuda:0', 'cpu').
+
+    Returns:
+        A new instance of the same dataclass with all tensors transferred to device.
+    """
+    field_values = {}
+    for field in fields(input_args):
+        value = getattr(input_args, field.name)
+        if isinstance(value, torch.Tensor):
+            field_values[field.name] = value.to(device)
+        else:
+            field_values[field.name] = value
+    return type(input_args)(**field_values)
 
 
 def global_to_local_projection_map(global_map: dict[str, ProjectionEntry], local_cols: list[int]) -> dict[str, dict]:


### PR DESCRIPTION
## Summary

`transfer_tensors_to_device` is generic dataclass-tensor plumbing — moving
it from `run_solver` into `utils/dist_utils` makes it reusable from
distributed setup code (which builds per-rank input args before any
`run_solver` call) without having to import from `run_solver`. Internal
behavior is unchanged; `run_solver` keeps using the same function via that
import.

## Test plan

- [x] Existing tests pass (`pytest tests/ --ignore=tests/distributed`)
- [x] `transfer_tensors_to_device` importable from both
      `dualip.utils.dist_utils` (canonical) and `dualip.run_solver` (re-export)
