### PR TITLE
ci: declare contents:write on docs workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -4,6 +4,10 @@ on:
     branches:
       - master
   workflow_dispatch:
+
+permissions:
+  contents: write
+
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The Docs workflow pushes to `gh-pages` through `peaceiris/actions-gh-pages@v3`, but doesn't currently declare a `permissions:` block. The default `GITHUB_TOKEN` scope therefore depends on the repo-level default (which can change), and a reader of the file has to infer the required scope from the third-party action.

Setting `permissions: contents: write` at workflow scope:

- pins the required scope explicitly so it survives a future change to the repo default
- documents that nothing else (issues, pull-requests, packages, id-token) is needed by the deploy
- matches the style ci.yaml and release.yaml already use, both of which carry workflow-level `permissions:` blocks

No behavioural change. `peaceiris/actions-gh-pages` still uses `${{ secrets.GITHUB_TOKEN }}` exactly as before, just with the scope spelled out.